### PR TITLE
Erase form cookie when submitting

### DIFF
--- a/_includes/better-forms.html
+++ b/_includes/better-forms.html
@@ -163,6 +163,9 @@
             scrollTop: ($('.error:visible:first').offset().top - 150) // 150px is an arbitrary amount to have the field better centered
         }, 300);
         }
+        else {
+		$(eraseCookie(formname));
+		}
     });
 
     $( document ).ready(function() {


### PR DESCRIPTION
When a user send the form with no error, the cookie is erased so the values are not displayed in the form anymore.