### PR TITLE
Fix lightbox

### DIFF
--- a/_includes/lightbox.html
+++ b/_includes/lightbox.html
@@ -1,7 +1,7 @@
 <style>
 .lightbox {width: 100%; height: 100%; position: fixed; top: 0; left: 0; background: rgba(0,0,0,0.85); z-index: 9999999; line-height: 0; cursor: pointer;}
 .lightbox .img {
-	position: relative; 
+	position: relative;
 	top: 50%;
 	left: 50%;
 	-ms-transform: translateX(-50%) translateY(-50%);
@@ -22,19 +22,19 @@
 	}
 }
 .lightbox span {
-		display: block; 
-		position: fixed; 
-		bottom: 13px; 
-		height: 1.5em; 
-		line-height: 1.4em; 
-		width: 100%; 
-		text-align: center; 
+		display: block;
+		position: fixed;
+		bottom: 13px;
+		height: 1.5em;
+		line-height: 1.4em;
+		width: 100%;
+		text-align: center;
 		color: white;
 		text-shadow:
     -1px -1px 0 #000,
     1px -1px 0 #000,
     -1px 1px 0 #000,
-    1px 1px 0 #000;  
+    1px 1px 0 #000;
 }
 
 {% if include.lightbox_captions == "false" %}.lightbox span {display: none;}{% endif %}
@@ -43,7 +43,7 @@
 {% if page.lightbox_captions == true %}.lightbox span {display: block;}{% endif %}
 
 .lightbox .videoWrapperContainer {
-	position: relative; 
+	position: relative;
 	top: 50%;
 	left: 50%;
 	-ms-transform: translateX(-50%) translateY(-50%);
@@ -60,7 +60,7 @@
 	position: relative;
 	padding-bottom: 56.333%; /* custom */
 	background: black;
-} 
+}
 .lightbox .videoWrapper iframe {
 	position: absolute;
 	top: 0;
@@ -69,7 +69,7 @@
 	height: 100%;
 	border: 0;
 	display: block;
-}   
+}
 .lightbox #prev, .lightbox #next {height: 50px; line-height: 36px; display: none; margin-top: -25px; position: fixed; top: 50%; padding: 0 15px; cursor: pointer; text-decoration: none; z-index: 99; color: white; font-size: 60px;}
 .lightbox.gallery #prev, .lightbox.gallery #next {display: block;}
 .lightbox #prev {left: 0;}
@@ -100,13 +100,16 @@ transform-origin: 50% 50%;
 -o-transform: rotate(45deg);
 }
 .lightbox, .lightbox * {
-    -webkit-user-select: none;  
-    -moz-user-select: none;    
-    -ms-user-select: none;      
-    user-select: none;
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+     -khtml-user-select: none; /* Konqueror HTML */
+       -moz-user-select: none; /* Old versions of Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome, Opera and Firefox */}
 }
 </style>
-		
+
 <script>
 function is_youtubelink(url) {
   var p = /^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/;
@@ -150,7 +153,7 @@ $(document).ready(function() {
 	//remove the clicked lightbox
 	$("body").on("click", ".lightbox", function(event){
 		if($(this).hasClass('gallery')) {
-			
+
 			$(this).remove();
 
 			if($(event.target).attr('id')=='next') {
@@ -201,7 +204,7 @@ $(document).ready(function() {
 		}
 	});
 
-	
+
 });
 
 $(document).keydown(function(e) {
@@ -226,7 +229,7 @@ $(document).keydown(function(e) {
   Swipe-it v1.4.1
   An event listener for swiping gestures with vanilla js.
   https://github.com/tri613/swipe-it#readme
- 
+
   @Create 2016/09/22
   @Update 2017/08/11
   @Author Trina Lu

--- a/_without-plugin/lightbox.md
+++ b/_without-plugin/lightbox.md
@@ -24,12 +24,12 @@ Note that I wrote this lightbox myself and tested it on a minimal amount of devi
 
 Step 1. Download the file [lightbox.html](https://raw.githubusercontent.com/jhvanderschee/jekyllcodex/gh-pages/_includes/lightbox.html)
 <br />Step 2. Save the file in the '_includes' directory of your project
-<br />Step 3. Make sure the bottom of your layout document looks like this:
+<br />Step 3. Make sure the head of your layout document looks like this:
 
 ```
 {% raw %}...
 <script src="/js/jquery.min.js"></script>
 {% include lightbox.html %}
-</body>
+</head>
 </html>{% endraw %}
 ```


### PR DESCRIPTION
Including lightbox.html in the body section leads to text selection issues.

The text on the page becomes unselectible.

I don't know why, but all that "user-select: none" works for global page scope, not only for "lightbox" style.

I tested it for Chrome for Mac.

Fixed in documentation, it now says that lightbox.html should be included in the head section.
